### PR TITLE
Fix meta tags for bookworm

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Configurable ansible role for setting up a nginx webserver on a Linux server. Wo
 
 - openSUSE Leap 15.5
 - openSUSE Leap 15.6
-- Debian Buster (11)
+- Debian Bookworm (11)
 
 ## Role Variables
 --------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,9 @@ galaxy_info:
       versions:
         - 15.5
         - 15.6
+    - name: debian
+      versions:
+        - bookworm
 
   galaxy_tags:
     - nginx


### PR DESCRIPTION
Re-add the accidentally removed meta tags for Debian bookworm.